### PR TITLE
refactor directory creation and fix file path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env sh
 echo "installing theme..."
+mkdir -p ~/.local/share/plasma/desktoptheme/
 cp -r Material-Ocean ~/.local/share/plasma/desktoptheme/
 echo "installing colorscheme..."
-cp MaterialOcean.colors ~/.local/share/color-schemes
+mkdir -p ~/.local/share/color-schemes/
+cp MaterialOcean.colors ~/.local/share/color-schemes/
 printf "Installation Successful!\nGo to settings and select the desktop theme and
 color scheme"


### PR DESCRIPTION
- Ensure the directory exists in Plasma by default (it does not exist by default), if not create it.
- Update the command to "cp MaterialOcean.colors ~/.local/share/color-schemes/" to correctly create a directory named "color-schemes" instead of a file.